### PR TITLE
Add function dumping

### DIFF
--- a/UEDumper/Engine/Core/Core.cpp
+++ b/UEDumper/Engine/Core/Core.cpp
@@ -560,6 +560,16 @@ bool EngineCore::generateStruct(UStruct* object, std::vector<EngineStructs::Stru
 			currentOffset = member.offset + member.size;
 			eStruct.members.push_back(member);
 		}
+
+		// get struct functions
+		for (auto child = object->getChildren(); child; child = child->GetNext())
+		{
+			if (!child->IsA<UFunction>())
+				continue;
+
+			auto fn = child->castTo<UFunction>();
+			generateFunction(fn, eStruct.functions);
+		}
 	}
 #endif
 	//fixup 
@@ -599,6 +609,47 @@ bool EngineCore::generateEnum(const UEnum* object, std::vector<EngineStructs::En
 
 	data.push_back(eEnum);
 
+	return true;
+}
+
+bool EngineCore::generateFunction(UFunction* object, std::vector<EngineStructs::Function>& data)
+{
+	EngineStructs::Function eFunction;
+	eFunction.fullName = object->getFullName();
+	eFunction.memoryAddress = object->objectptr;
+	eFunction.flags = object->getFunctionFlagsString();
+	eFunction.func = object->Func;
+
+	for (auto child = object->getChildProperties(); child; child = child->getNext()) 
+	{
+		auto propertyFlags = child->PropertyFlags;
+		if (propertyFlags & EPropertyFlags::CPF_ReturnParm)
+			eFunction.cppName = child->getType().name + " " + object->getName();
+		else if (propertyFlags & EPropertyFlags::CPF_Parm)
+		{
+			if (child->ArrayDim > 1)
+				eFunction.params += child->getType().name + "* " + child->getName() + ", ";
+			else
+			{
+				if (propertyFlags & EPropertyFlags::CPF_OutParm)
+					eFunction.params += child->getType().name + "& " + child->getName() + ", ";
+				else
+					eFunction.params += child->getType().name + " " + child->getName() + ", ";
+			}
+		}
+	}
+
+	// remove trailing ", " from params
+	if (eFunction.params.size())
+		eFunction.params.erase(eFunction.params.size() - 2);
+	else
+		eFunction.params = "";
+
+	// no defined return type => void
+	if (eFunction.cppName.size() == 0)
+		eFunction.cppName = "void " + object->getName();
+
+	data.push_back(eFunction);
 	return true;
 }
 
@@ -920,7 +971,6 @@ void EngineCore::generatePackages(int64_t& finishedPackages, int64_t& totalPacka
 				//enums do not have CNames
 				packageObjectInfos.insert(std::pair(eObject->getName(), ObjectInfo(false, packageIndex, p.enums.size() - 1)));
 			}
-			
 		}
 		p.itemCount = p.structs.size() + p.enums.size();
 		packages.push_back(p);

--- a/UEDumper/Engine/Core/Core.h
+++ b/UEDumper/Engine/Core/Core.h
@@ -30,6 +30,7 @@
 //forwarded classes
 class UEnum;
 class UStruct;
+class UFunction;
 class FFieldClass;
 class UProperty;
 
@@ -39,6 +40,7 @@ namespace EngineStructs
 	struct Member;
 	struct Struct;
 	struct Enum;
+	struct Function;
 	struct Package;
 }
 
@@ -250,6 +252,12 @@ private:
 	 * \param data Enum where the enum fields are going to be added
 	 */
 	static bool generateEnum(const UEnum* object, std::vector<EngineStructs::Enum>& data);
+	/**
+	* \brief generates a function for the specific function
+	* \param object UFunction from memory with all its data
+	* \param data Function where the function is going to be added
+	*/
+	static bool generateFunction(UFunction* object, std::vector<EngineStructs::Function>& data);
 	
 public:
 

--- a/UEDumper/Engine/Core/EngineStructs.h
+++ b/UEDumper/Engine/Core/EngineStructs.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <algorithm>
 #include <vector>
+#include <cstdint>
 
 #include "../structs.h"
 
@@ -132,6 +133,41 @@ namespace EngineStructs
 	};
 
 	/**
+	 * \brief Function struct. Contains info about a single function
+	 */
+	struct Function
+	{
+		uintptr_t memoryAddress;
+		std::string fullName;
+		std::string cppName;
+		std::string params;
+		std::string flags;
+		uint64_t func = 0;
+
+		nlohmann::json toJson() const
+		{
+			nlohmann::json j;
+			j["memoryAddress"] = memoryAddress;
+			j["fullName"] = fullName;
+			j["cppName"] = cppName;
+			j["flags"] = flags;
+			j["func"] = func;
+			return j;
+		}
+
+		static Function fromJson(const nlohmann::json& json)
+		{
+			Function f;
+			f.memoryAddress = json["memoryAddress"];
+			f.fullName = json["fullName"];
+			f.cppName = json["cppName"];
+			f.flags = json["flags"];
+			f.func = json["func"];
+			return f;
+		}
+	};
+
+	/**
 	 * \brief Struct/Class struct. Contains members and information about the Struct/Class
 	 */
 	struct Struct
@@ -146,6 +182,7 @@ namespace EngineStructs
 		int inheretedSize = 0; //size of the inherited structs
 		int unknownCount = 0; //keep track of all missed vars, only used for the package viewer to edit unknowndata
 		std::vector<Member> members{}; //array of all members of the struct
+		std::vector<Function> functions{}; //array of all functions of the struct
 
 		bool operator==(const Struct& st) const
 		{
@@ -168,6 +205,10 @@ namespace EngineStructs
 			for (const auto& member : members)
 				jMembers.push_back(member.toJson());
 			j["members"] = jMembers;
+			nlohmann::json jFunctions;
+			for (const auto& fn : functions)
+				jFunctions.push_back(fn.toJson());
+			j["functions"] = jFunctions;
 			return j;
 		}
 
@@ -186,6 +227,9 @@ namespace EngineStructs
 			const nlohmann::json jMembers = json["members"];
 			for (const nlohmann::json& member : jMembers)
 				s.members.push_back(Member::fromJson(member));
+			const nlohmann::json jFunctions = json["functions"];
+			for (const nlohmann::json& fn : jFunctions)
+				s.functions.push_back(Function::fromJson(fn));
 
 			return s;
 		}

--- a/UEDumper/Engine/UEClasses/UnrealClasses.cpp
+++ b/UEDumper/Engine/UEClasses/UnrealClasses.cpp
@@ -304,6 +304,77 @@ UClass* UScriptStruct::staticClass()
     return EngineCore::findObject<UClass>("/Script/CoreUObject.ScriptStruct");
 }
 
+std::string UFunction::getFunctionFlagsString() const {
+    auto flags = FunctionFlags;
+    std::string result;
+    if (flags == FUNC_None)
+        result = "None";
+    else 
+    {
+        if (flags & FUNC_Final)
+            result += "Final|";
+        if (flags & FUNC_RequiredAPI)
+            result += "RequiredAPI|";
+        if (flags & FUNC_BlueprintAuthorityOnly)
+            result += "BlueprintAuthorityOnly|";
+        if (flags & FUNC_BlueprintCosmetic)
+            result += "BlueprintCosmetic|";
+        if (flags & FUNC_Net)
+            result += "Net|";
+        if (flags & FUNC_NetReliable)
+            result += "NetReliable";
+        if (flags & FUNC_NetRequest)
+            result += "NetRequest|";
+        if (flags & FUNC_Exec)
+            result += "Exec|";
+        if (flags & FUNC_Native)
+            result += "Native|";
+        if (flags & FUNC_Event)
+            result += "Event|";
+        if (flags & FUNC_NetResponse)
+            result += "NetResponse|";
+        if (flags & FUNC_Static)
+            result += "Static|";
+        if (flags & FUNC_NetMulticast)
+            result += "NetMulticast|";
+        if (flags & FUNC_MulticastDelegate)
+            result += "MulticastDelegate|";
+        if (flags & FUNC_Public)
+            result += "Public|";
+        if (flags & FUNC_Private)
+            result += "Private|";
+        if (flags & FUNC_Protected)
+            result += "Protected|";
+        if (flags & FUNC_Delegate)
+            result += "Delegate|";
+        if (flags & FUNC_NetServer)
+            result += "NetServer|";
+        if (flags & FUNC_HasOutParms)
+            result += "HasOutParms|";
+        if (flags & FUNC_HasDefaults)
+            result += "HasDefaults|";
+        if (flags & FUNC_NetClient)
+            result += "NetClient|";
+        if (flags & FUNC_DLLImport)
+            result += "DLLImport|";
+        if (flags & FUNC_BlueprintCallable)
+            result += "BlueprintCallable|";
+        if (flags & FUNC_BlueprintEvent)
+            result += "BlueprintEvent|";
+        if (flags & FUNC_BlueprintPure)
+            result += "BlueprintPure|";
+        if (flags & FUNC_EditorOnly)
+            result += "EditorOnly|";
+        if (flags & FUNC_Const)
+            result += "Const|";
+        if (flags & FUNC_NetValidate)
+            result += "NetValidate|";
+        if (result.size())
+            result.erase(result.size() - 1);
+    }
+    return result;
+}
+
 UClass* UFunction::staticClass()
 {
     return EngineCore::findObject<UClass>("/Script/CoreUObject.Function");

--- a/UEDumper/Engine/UEClasses/UnrealClasses.h
+++ b/UEDumper/Engine/UEClasses/UnrealClasses.h
@@ -311,6 +311,8 @@ public:
 	/** C++ function this is bound to */
 	uintptr_t		Func;
 
+	/** String function flags */
+	std::string getFunctionFlagsString() const;
 
 	static UClass* staticClass();
 };
@@ -751,9 +753,8 @@ public:
 
 	UEnum* getEnum() const;
 
-	 std::string typeName() const { return getEnum()->getName(); }
-	 
-
+	std::string typeName() const { return getEnum()->getName(); }
+	
 	static UClass* staticClass();
 };
 

--- a/UEDumper/Engine/enums.h
+++ b/UEDumper/Engine/enums.h
@@ -164,6 +164,69 @@ enum EFunctionFlags : uint32_t
 	FUNC_AllFlags				= 0xFFFFFFFF,
 };
 
+// https://github.com/EpicGames/UnrealEngine/blob/463443057fb97f1af0d2951705324ce8818d2a55/Engine/Source/Runtime/CoreUObject/Public/UObject/ObjectMacros.h#L392
+enum EPropertyFlags : uint64_t
+{
+	CPF_None = 0,
+
+	CPF_Edit = 0x0000000000000001,	///< Property is user-settable in the editor.
+	CPF_ConstParm = 0x0000000000000002,	///< This is a constant function parameter
+	CPF_BlueprintVisible = 0x0000000000000004,	///< This property can be read by blueprint code
+	CPF_ExportObject = 0x0000000000000008,	///< Object can be exported with actor.
+	CPF_BlueprintReadOnly = 0x0000000000000010,	///< This property cannot be modified by blueprint code
+	CPF_Net = 0x0000000000000020,	///< Property is relevant to network replication.
+	CPF_EditFixedSize = 0x0000000000000040,	///< Indicates that elements of an array can be modified, but its size cannot be changed.
+	CPF_Parm = 0x0000000000000080,	///< Function/When call parameter.
+	CPF_OutParm = 0x0000000000000100,	///< Value is copied out after function call.
+	CPF_ZeroConstructor = 0x0000000000000200,	///< memset is fine for construction
+	CPF_ReturnParm = 0x0000000000000400,	///< Return value.
+	CPF_DisableEditOnTemplate = 0x0000000000000800,	///< Disable editing of this property on an archetype/sub-blueprint
+	CPF_NonNullable = 0x0000000000001000,	///< Object property can never be null
+	CPF_Transient = 0x0000000000002000,	///< Property is transient: shouldn't be saved or loaded, except for Blueprint CDOs.
+	CPF_Config = 0x0000000000004000,	///< Property should be loaded/saved as permanent profile.
+	CPF_RequiredParm = 0x0000000000008000,	///< Parameter must be linked explicitly in blueprint. Leaving the parameter out results in a compile error. 
+	CPF_DisableEditOnInstance = 0x0000000000010000,	///< Disable editing on an instance of this class
+	CPF_EditConst = 0x0000000000020000,	///< Property is uneditable in the editor.
+	CPF_GlobalConfig = 0x0000000000040000,	///< Load config from base class, not subclass.
+	CPF_InstancedReference = 0x0000000000080000,	///< Property is a component references.
+	//CPF_								= 0x0000000000100000,	///<
+	CPF_DuplicateTransient = 0x0000000000200000,	///< Property should always be reset to the default value during any type of duplication (copy/paste, binary duplication, etc.)
+	//CPF_								= 0x0000000000400000,	///< 
+	//CPF_    							= 0x0000000000800000,	///< 
+	CPF_SaveGame = 0x0000000001000000,	///< Property should be serialized for save games, this is only checked for game-specific archives with ArIsSaveGame
+	CPF_NoClear = 0x0000000002000000,	///< Hide clear (and browse) button.
+	//CPF_  							= 0x0000000004000000,	///<
+	CPF_ReferenceParm = 0x0000000008000000,	///< Value is passed by reference; CPF_OutParam and CPF_Param should also be set.
+	CPF_BlueprintAssignable = 0x0000000010000000,	///< MC Delegates only.  Property should be exposed for assigning in blueprint code
+	CPF_Deprecated = 0x0000000020000000,	///< Property is deprecated.  Read it from an archive, but don't save it.
+	CPF_IsPlainOldData = 0x0000000040000000,	///< If this is set, then the property can be memcopied instead of CopyCompleteValue / CopySingleValue
+	CPF_RepSkip = 0x0000000080000000,	///< Not replicated. For non replicated properties in replicated structs 
+	CPF_RepNotify = 0x0000000100000000,	///< Notify actors when a property is replicated
+	CPF_Interp = 0x0000000200000000,	///< interpolatable property for use with cinematics
+	CPF_NonTransactional = 0x0000000400000000,	///< Property isn't transacted
+	CPF_EditorOnly = 0x0000000800000000,	///< Property should only be loaded in the editor
+	CPF_NoDestructor = 0x0000001000000000,	///< No destructor
+	//CPF_								= 0x0000002000000000,	///<
+	CPF_AutoWeak = 0x0000004000000000,	///< Only used for weak pointers, means the export type is autoweak
+	CPF_ContainsInstancedReference = 0x0000008000000000,	///< Property contains component references.
+	CPF_AssetRegistrySearchable = 0x0000010000000000,	///< asset instances will add properties with this flag to the asset registry automatically
+	CPF_SimpleDisplay = 0x0000020000000000,	///< The property is visible by default in the editor details view
+	CPF_AdvancedDisplay = 0x0000040000000000,	///< The property is advanced and not visible by default in the editor details view
+	CPF_Protected = 0x0000080000000000,	///< property is protected from the perspective of script
+	CPF_BlueprintCallable = 0x0000100000000000,	///< MC Delegates only.  Property should be exposed for calling in blueprint code
+	CPF_BlueprintAuthorityOnly = 0x0000200000000000,	///< MC Delegates only.  This delegate accepts (only in blueprint) only events with BlueprintAuthorityOnly.
+	CPF_TextExportTransient = 0x0000400000000000,	///< Property shouldn't be exported to text format (e.g. copy/paste)
+	CPF_NonPIEDuplicateTransient = 0x0000800000000000,	///< Property should only be copied in PIE
+	CPF_ExposeOnSpawn = 0x0001000000000000,	///< Property is exposed on spawn
+	CPF_PersistentInstance = 0x0002000000000000,	///< A object referenced by the property is duplicated like a component. (Each actor should have an own instance.)
+	CPF_UObjectWrapper = 0x0004000000000000,	///< Property was parsed as a wrapper class like TSubclassOf<T>, FScriptInterface etc., rather than a USomething*
+	CPF_HasGetValueTypeHash = 0x0008000000000000,	///< This property can generate a meaningful hash value.
+	CPF_NativeAccessSpecifierPublic = 0x0010000000000000,	///< Public native access specifier
+	CPF_NativeAccessSpecifierProtected = 0x0020000000000000,	///< Protected native access specifier
+	CPF_NativeAccessSpecifierPrivate = 0x0040000000000000,	///< Private native access specifier
+	CPF_SkipSerialization = 0x0080000000000000,	///< Property shouldn't be serialized, can still be exported to text
+};
+
 // https://github.com/EpicGames/UnrealEngine/blob/4.25/Engine/Source/Runtime/CoreUObject/Public/UObject/ObjectMacros.h#L474
 enum EObjectFlags : uint32_t
 {

--- a/UEDumper/Frontend/Windows/PackageViewerWindow.cpp
+++ b/UEDumper/Frontend/Windows/PackageViewerWindow.cpp
@@ -399,6 +399,25 @@ void windows::PackageViewerWindow::generatePackage(std::ofstream& file, const En
             file << std::endl;
 
         }
+
+        // Add function section header
+        if (!struc.functions.empty()) 
+        {
+            file << "\n\t/// Functions";
+            char headerBuf[300];
+            sprintf_s(headerBuf, "\n\t/// %-50s %-60s %-50s %-20s   [%s]", "ReturnType FunctionName", "(Parameters);", "Full Function Name", "(Function Flags)", "[Offset]");
+            file << headerBuf << std::endl;
+        }
+
+        for (const auto& func : struc.functions)
+        {
+            char finalBuf[1200];
+            char nameBuf[1000];
+            sprintf_s(nameBuf, "%-50s(%s);", func.cppName.c_str(), func.params.c_str());
+            auto offset = func.memoryAddress - Memory::getBaseAddress();
+            sprintf_s(finalBuf, "	%-110s // %-50s    (%-10s)    [0x%llx]", nameBuf, func.fullName.c_str(), func.flags.c_str(), offset);
+            file << finalBuf << std::endl;
+        }
         file << "};\n\n";
 
     }


### PR DESCRIPTION
This is a significant addition, though I know you already planned it. I wanted function dumping for an internal, so I made an initial version. You might already be working on yours, but if not I am putting mine up for review since it's at a decent functional starting point. I followed your modified UnrealDumper-4.25 setup as best I could since I know that is how you have structured the rest of the dumping

Things that may need to change with your input:
- [ ] Output syntax/style for dumped functions (return type/name/params placement)
- [ ] Should function dumping be an optional engine setting (like WITH_LIVE_CODING)?
- [ ] I haven't looked into the Dumps.host compatibility, but I did modify the structs toJson and fromJson
- [ ] Need to test with UE<4.25, I've currently only tested with UE 5.1 currently
- [ ] Does anything need to change with the Live Editor? (Not sure if functions being shown there would be desired anyways)

I'm happy to make any modifications as you would like, or you are more than welcome to work on your own implementation that you may have already been working on and have it as a reference