### PR TITLE
Refactor function struct for accessible fieldTypes

### DIFF
--- a/UEDumper/Engine/Core/Core.cpp
+++ b/UEDumper/Engine/Core/Core.cpp
@@ -631,30 +631,30 @@ bool EngineCore::generateFunction(UFunction* object, std::vector<EngineStructs::
 	{
 		auto propertyFlags = child->PropertyFlags;
 		if (propertyFlags & EPropertyFlags::CPF_ReturnParm)
-			eFunction.cppName = child->getType().name + " " + object->getName();
+			eFunction.returnType = child->getType();
 		else if (propertyFlags & EPropertyFlags::CPF_Parm)
 		{
 			if (child->ArrayDim > 1)
-				eFunction.params += child->getType().name + "* " + child->getName() + ", ";
+				eFunction.params.push_back(std::pair(child->getType(), "* " + child->getName() + ", "));
 			else
 			{
 				if (propertyFlags & EPropertyFlags::CPF_OutParm)
-					eFunction.params += child->getType().name + "& " + child->getName() + ", ";
+					eFunction.params.push_back(std::pair(child->getType(), "& " + child->getName() + ", "));
 				else
-					eFunction.params += child->getType().name + " " + child->getName() + ", ";
+					eFunction.params.push_back(std::pair(child->getType(), " " + child->getName() + ", "));
 			}
 		}
 	}
 
-	// remove trailing ", " from params
+	// remove trailing ", " from last param name
 	if (eFunction.params.size())
-		eFunction.params.erase(eFunction.params.size() - 2);
-	else
-		eFunction.params = "";
+		eFunction.params.back().second.erase(eFunction.params.back().second.size() - 2);
 
 	// no defined return type => void
 	if (eFunction.cppName.size() == 0)
-		eFunction.cppName = "void " + object->getName();
+		eFunction.returnType = { false, PropertyType::StructProperty, "void" };
+
+	eFunction.cppName = eFunction.returnType.name + " " + object->getName();
 
 	data.push_back(eFunction);
 	return true;

--- a/UEDumper/Engine/Core/EngineStructs.h
+++ b/UEDumper/Engine/Core/EngineStructs.h
@@ -138,9 +138,10 @@ namespace EngineStructs
 	struct Function
 	{
 		uintptr_t memoryAddress;
+		fieldType returnType;
+		std::vector<std::pair<fieldType, std::string>> params;
 		std::string fullName;
 		std::string cppName;
-		std::string params;
 		std::string flags;
 		uint64_t func = 0;
 
@@ -148,6 +149,11 @@ namespace EngineStructs
 		{
 			nlohmann::json j;
 			j["memoryAddress"] = memoryAddress;
+			j["returnType"] = returnType.toJson();
+			nlohmann::json jParams;
+			for (const auto& param : params)
+				jParams.push_back({param.first.toJson(), param.second});
+			j["params"] = jParams;
 			j["fullName"] = fullName;
 			j["cppName"] = cppName;
 			j["flags"] = flags;
@@ -159,6 +165,10 @@ namespace EngineStructs
 		{
 			Function f;
 			f.memoryAddress = json["memoryAddress"];
+			f.returnType = fieldType::fromJson(json["returnType"]);
+			const nlohmann::json jParams = json["params"];
+			for (const nlohmann::json& param : jParams)
+				f.params.push_back(std::pair(fieldType::fromJson(param[0]), param[1]));
 			f.fullName = json["fullName"];
 			f.cppName = json["cppName"];
 			f.flags = json["flags"];

--- a/UEDumper/Frontend/Windows/PackageViewerWindow.cpp
+++ b/UEDumper/Frontend/Windows/PackageViewerWindow.cpp
@@ -405,18 +405,20 @@ void windows::PackageViewerWindow::generatePackage(std::ofstream& file, const En
         {
             file << "\n\t/// Functions";
             char headerBuf[300];
-            sprintf_s(headerBuf, "\n\t/// %-50s %-60s %-50s %-20s   [%s]", "ReturnType FunctionName", "(Parameters);", "Full Function Name", "(Function Flags)", "[Offset]");
+            sprintf_s(headerBuf, "\n\t/// %-46s %-60s %-63s %-20s %s", "ReturnType FunctionName", "(Parameters);", "Full Function Name", "(Function Flags)", "[Offset]");
             file << headerBuf << std::endl;
         }
 
         for (const auto& func : struc.functions)
         {
-            char finalBuf[1200];
-            char nameBuf[1000];
-            sprintf_s(nameBuf, "%-50s(%s);", func.cppName.c_str(), func.params.c_str());
+            char funcBuf[1200];
+            std::string params = "(";
+            for (auto param : func.params)
+                params += param.first.name + " " + param.second;
+            params += ");";
             auto offset = func.memoryAddress - Memory::getBaseAddress();
-            sprintf_s(finalBuf, "	%-110s // %-50s    (%-10s)    [0x%llx]", nameBuf, func.fullName.c_str(), func.flags.c_str(), offset);
-            file << finalBuf << std::endl;
+            sprintf_s(funcBuf, "	%-50s %-60s // %-60s %-20s [0x%llx]", func.cppName.c_str(), params.c_str(), func.fullName.c_str(), func.flags.c_str(), offset);
+            file << funcBuf << std::endl;
         }
         file << "};\n\n";
 


### PR DESCRIPTION
As we discussed, here is my rework to make the function return type and parameter fieldTypes accessible to the frontend

The function struct in this implementation now contains a vector of <fieldType, string> pairs where the fieldType is the type and the string is the parameter name (along with if the parameter is a pointer, reference, or regular

Ex: pair(UObject (as fieldType), "* objectPointer")

This is so that in the front end, you can iterate through the parameters and display the parameter type as a clickable button since it will now be stored as a fieldType and then print the "*" or "&" and the parameter name just as text afterward

---

This is the first idea that came to mind, but I told you I'd send it. If something else makes more sense when you are working on the front-end stuff, that also works! Thanks