### PR TITLE
Add a circuit breaker in MDK generation if we can't converge on cyclic import resolution

### DIFF
--- a/UEDumper/Engine/Generation/MDK.cpp
+++ b/UEDumper/Engine/Generation/MDK.cpp
@@ -514,9 +514,15 @@ void MDKGeneration::generate(int& progressDone, int& totalProgress)
 	windows::LogWindow::Log(windows::LogWindow::logLevels::LOGLEVEL_INFO, "MDK GEN", "Reordering packages");
 	std::vector<MergedPackage*> orderedPackages;
 
+	const float one_thousand = 1000;
+	// Max number of iterations before we give up
+	// Using some very large number - it's to prevent infinite loops, not break too early before convergence
+	const auto maxIterations = 20 * one_thousand;
+	progressDone = 0;
+	totalProgress = maxIterations; // Note: we may converge before this and end up with a Microsoft style progress bar that magically jumps to 100%} while (didReordering && progressDone < totalProgress);
+
 	do
 	{
-		progressDone = 0;
 		didReordering = false;
 		for (auto& p : newPackages)
 		{
@@ -573,7 +579,16 @@ void MDKGeneration::generate(int& progressDone, int& totalProgress)
 				}
 			}
 		}
-	} while (didReordering);
+	} while (didReordering && progressDone < totalProgress);
+	if (didReordering)
+	{
+		windows::LogWindow::Log(windows::LogWindow::logLevels::LOGLEVEL_ERROR, "MDK GEN", "Unable to resolve cyclic import dependencies after %.2fK iterations", progressDone / one_thousand);
+	}
+	else
+	{
+		windows::LogWindow::Log(windows::LogWindow::logLevels::LOGLEVEL_INFO, "MDK GEN", "Converged imports after %.2fK iterations", progressDone / one_thousand);
+		progressDone = totalProgress;
+	}
 
 
 	puts("------sorted packages------");

--- a/UEDumper/Engine/Generation/MDK.cpp
+++ b/UEDumper/Engine/Generation/MDK.cpp
@@ -519,7 +519,7 @@ void MDKGeneration::generate(int& progressDone, int& totalProgress)
 	// Using some very large number - it's to prevent infinite loops, not break too early before convergence
 	const auto maxIterations = 20 * one_thousand;
 	progressDone = 0;
-	totalProgress = maxIterations; // Note: we may converge before this and end up with a Microsoft style progress bar that magically jumps to 100%} while (didReordering && progressDone < totalProgress);
+	totalProgress = maxIterations; // Note: we may converge before this and end up with a Microsoft style progress bar that magically jumps to 100% while (didReordering && progressDone < totalProgress);
 
 	do
 	{


### PR DESCRIPTION
Currently in some cases it's possible for the MDK/SDK generation to go into an infinite loop where it can't converge.

This adds a circuit breaker to cap the maximum number of iterations before we consider it a lost cause, and go with a best effort generation.

Note: I'm not entirely happy with the change to how the progress bar works - if we do successfully converge, we'll have a Microsoft style progress bar that just jumps from 1% to 100% for example. However I think it's better than having the progress bar constantly resetting, as the user may not wait it out fully and assume it's stuck and that there's no end in sight.