### PR TITLE
Fix CoreUObject having a maxsize of zero causing incorrect missing member sizing of subclasses

### DIFF
--- a/UEDumper/Engine/Core/Core.cpp
+++ b/UEDumper/Engine/Core/Core.cpp
@@ -696,9 +696,12 @@ void EngineCore::cookMemberArray(EngineStructs::Struct & eStruct)
 
 	if (eStruct.inherited)
 	{
-		if (eStruct.inheretedSize < eStruct.definedMembers[0].offset)
+		const auto& inherStruct = eStruct.supers[0];
+		// in some cases, CoreUObject may have a zero maxSize, which leads to incorrect SDK generation
+		auto parentSize = inherStruct->maxSize == 0 ? eStruct.inheretedSize : inherStruct->maxSize;
+		if (parentSize < eStruct.definedMembers[0].offset)
 		{
-			genUnknownMember(eStruct.inheretedSize, eStruct.definedMembers[0].offset, 3);
+			genUnknownMember(parentSize, eStruct.definedMembers[0].offset, 3);
 		}
 	}
 

--- a/UEDumper/Engine/Core/Core.cpp
+++ b/UEDumper/Engine/Core/Core.cpp
@@ -696,12 +696,10 @@ void EngineCore::cookMemberArray(EngineStructs::Struct & eStruct)
 
 	if (eStruct.inherited)
 	{
-		const auto& inherStruct = eStruct.supers[0];
-		if (inherStruct->maxSize < eStruct.definedMembers[0].offset)
+		if (eStruct.inheretedSize < eStruct.definedMembers[0].offset)
 		{
-			genUnknownMember(inherStruct->maxSize, eStruct.definedMembers[0].offset, 3);
+			genUnknownMember(eStruct.inheretedSize, eStruct.definedMembers[0].offset, 3);
 		}
-
 	}
 
 

--- a/UEDumper/Engine/Userdefined/StructDefinitions.h
+++ b/UEDumper/Engine/Userdefined/StructDefinitions.h
@@ -40,6 +40,7 @@ inline void overrideStructs()
 	uObject.fullName = "/Script/CoreUObject.Object"; //the full name
 	uObject.cppName = "UObject"; //cpp name
 	uObject.size = sizeof(UObject); //this works, because if UObject in engine != UObject in game the UEDumper will fail anyways
+	uObject.maxSize = uObject.size;
 	uObject.inherited = false; //is not inherited
 	uObject.isClass = true; //is it a class? - Yes
 
@@ -69,6 +70,7 @@ inline void overrideStructs()
 	uField.fullName = "/Script/CoreUObject.Field";
 	uField.cppName = "UField";
 	uField.size = sizeof(UField);
+	uField.maxSize = uField.size;
 	uField.isClass = true;
 	uField.inherited = true; //Ufield is inherited
 	uField.inheretedSize = sizeof(UObject); //you can use the size from our UnrealClasses
@@ -96,6 +98,7 @@ inline void overrideStructs()
 #endif
 	uStruct.cppName = "UStruct";
 	uStruct.size = sizeof(UStruct);
+	uStruct.maxSize = uStruct.size;
 	uStruct.isClass = true;
 	uStruct.inherited = true; //Ufield is inherited
 	uStruct.inheretedSize = sizeof(UField); //you can use the size from our UnrealClasses
@@ -125,6 +128,7 @@ inline void addStructs()
 	Fname.fullName = "/Custom/FName"; //Any fullname, preferable with /Custom/ at the beginning
 	Fname.cppName = "FName";
 	Fname.size = sizeof(FName);
+	Fname.maxSize = Fname.size;
 	Fname.isClass = false; //FName is just a struct
 	Fname.inherited = false;
 	int FnameOffset = 0;
@@ -156,6 +160,7 @@ inline void addStructs()
 	Tarray.cppName = "TArray";
 	Tarray.isClass = false;
 	Tarray.size = sizeof(TArray<uint64_t>);
+	Tarray.maxSize = Tarray.size;
 	Tarray.inherited = false;
 	int TarrayOffset = 0;
 	Tarray.definedMembers = std::vector<EngineStructs::Member>{


### PR DESCRIPTION
When generating an SDK, there's a scenario whereby maxSize of `/Script/CoreUObject.Object` can be zero.
This leads to a situation whereby we add the missing member on the assumption that CoreUObject has a zero size/no members, resulting in a bugged SDK due to excess padding (e.g. members may be offset by 0x30 bytes for example).

For example, beforehand we had a UWorld like this in Back4Blood's SDK:
```
/// Class /Script/Engine.World
/// Size: 0x0708 (0x000030 - 0x000738)
class UWorld : public UObject
{ 
public:
	unsigned char                                      UnknownData00_3[0x38];
	class ULevel*                                      PersistentLevel;
```

whereas now with the fix, it's instead:
```
/// Class /Script/Engine.World
/// Size: 0x0708 (0x000030 - 0x000738)
class UWorld : public UObject
{ 
public:
	unsigned char                                      UnknownData00_3[0x10]
	class ULevel*                                      PersistentLevel;
```