### PR TITLE
Add support for internal SDK generation with function bodies and includes

### DIFF
--- a/UEDumper/Engine/Core/Core.cpp
+++ b/UEDumper/Engine/Core/Core.cpp
@@ -1227,7 +1227,14 @@ void EngineCore::finishPackages()
 				{
 					const auto info = getInfoOfObject(type.name);
 					if (info && info->valid)
+					{
 						type.info = info;
+
+						//casting is fine even if its a enum as owningpackage is the first package
+						const auto targetStruc = static_cast<EngineStructs::Struct*>(info->target);
+						if (targetStruc->owningPackage->index != package.index)
+							package.dependencyPackages.insert(targetStruc->owningPackage);
+					}
 				}
 			};
 			addInfoPtr(ret);

--- a/UEDumper/Engine/Core/EngineStructs.h
+++ b/UEDumper/Engine/Core/EngineStructs.h
@@ -127,32 +127,32 @@ struct fieldType
 		return arr;
 	}
 
-	std::string stringify() const
+	std::string stringify(bool bAddTypePrefix = true) const
 	{
 
 		auto generateValidVarName = [](const std::string& str)
-		{
-			//hacky way to ignore shit like unsigned char get to unsigned_char
-			if (getSize(str) != -1)
-				return str;
-			std::string result = "";
-
-			for (const char c : str)
 			{
-				if (static_cast<int>(c) < 0 || !std::isalnum(c))
-					result += '_';
-				else
-					result += c;
+				//hacky way to ignore shit like unsigned char get to unsigned_char
+				if (getSize(str) != -1)
+					return str;
+				std::string result = "";
 
-			}
-			//guaranteed 0 termination
-			return result;
-		};
+				for (const char c : str)
+				{
+					if (static_cast<int>(c) < 0 || !std::isalnum(c))
+						result += '_';
+					else
+						result += c;
+
+				}
+				//guaranteed 0 termination
+				return result;
+			};
 
 
 		std::string typeStr = generateValidVarName(name);
 
-		if ((propertyType == PropertyType::ObjectProperty || propertyType == PropertyType::ClassProperty) && (info && info->valid))
+		if (bAddTypePrefix && (propertyType == PropertyType::ObjectProperty || propertyType == PropertyType::ClassProperty) && (info && info->valid))
 		{
 			const std::string prefix = info->type == ObjectInfo::OI_Class ? "class " : "struct ";
 			typeStr = prefix + typeStr;

--- a/UEDumper/Engine/Generation/SDK.h
+++ b/UEDumper/Engine/Generation/SDK.h
@@ -22,7 +22,7 @@ public:
 
 	static void printCredits(std::ofstream& stream);
 
-	static void generatePackage(std::ofstream& stream, const EngineStructs::Package& package);
+	static void generatePackage(std::ofstream& stream, const EngineStructs::Package& package, int featureFlags, std::unordered_map<std::string, std::string> &originalPackageToMerged);
 
-	static void Generate(int& progressDone, int& totalProgress);
+	static void Generate(int& progressDone, int& totalProgress, int featureFlags);
 };

--- a/UEDumper/FeatureFlags.h
+++ b/UEDumper/FeatureFlags.h
@@ -1,0 +1,14 @@
+#pragma once
+
+namespace FeatureFlags {
+	namespace SDK {
+		// bitmask
+		const static int FUNCTION_BODIES = 1 << 0;
+		const static int FORWARD_DECLARATIONS = 1 << 1;
+		const static int ADD_INCLUDES = 1 << 2;
+		const static int STRUCTS_BEFORE_CLASSES = 1 << 3;
+
+		const static int STABLE = 0;
+		const static int EXPERIMENTAL_INTERNAL = FUNCTION_BODIES | FORWARD_DECLARATIONS | ADD_INCLUDES | STRUCTS_BEFORE_CLASSES;
+	}
+}

--- a/UEDumper/Frontend/Windows/PackageWindow.cpp
+++ b/UEDumper/Frontend/Windows/PackageWindow.cpp
@@ -12,6 +12,7 @@
 #include "Engine/Generation/MDK.h"
 #include "Engine/Generation/SDK.h"
 #include "Frontend/Fonts/fontAwesomeHelper.h"
+#include "FeatureFlags.h"
 
 void windows::PackageWindow::renderUndefinedStructs()
 {
@@ -113,7 +114,8 @@ bool windows::PackageWindow::render()
 				std::ofstream file(EngineSettings::getWorkingDirectory() / (packages[packagePicked].packageName + ".h"));
 				SDKGeneration::printCredits(file);
 				file << "/// Package " + packages[packagePicked].packageName << ".\n\n";
-				SDKGeneration::generatePackage(file, packages[packagePicked]);
+				auto emptyMerged = std::unordered_map<std::string, std::string>{};
+				SDKGeneration::generatePackage(file, packages[packagePicked], FeatureFlags::SDK::STABLE, emptyMerged);
 				LogWindow::Log(LogWindow::logLevels::LOGLEVEL_INFO, "PACKAGE", "Saved Package %s to disk!", packages[packagePicked].packageName.c_str());
 			}
 			if (ImGui::Button("Copy package name"))
@@ -262,7 +264,19 @@ void windows::PackageWindow::renderProjectPopup()
 		anyProgressTotal = 1;
 		std::make_unique<std::future<void>*>(new auto(std::async(std::launch::async, [] {
 			LogWindow::Log(LogWindow::logLevels::LOGLEVEL_INFO, "PACKAGEWINDOW", "Creating SDK...");
-			SDKGeneration::Generate(anyProgressDone, anyProgressTotal);
+			SDKGeneration::Generate(anyProgressDone, anyProgressTotal, FeatureFlags::SDK::STABLE);
+			LogWindow::Log(LogWindow::logLevels::LOGLEVEL_INFO, "PACKAGEWINDOW", "Done!");
+			presentTopMostCallback = false;
+			}))).reset();
+	}
+	if (ImGui::Button(merge(ICON_FA_DOWNLOAD, " Generate internal SDK (experimental)")))
+	{
+		presentTopMostCallback = true;
+		anyProgressDone = 0;
+		anyProgressTotal = 1;
+		std::make_unique<std::future<void>*>(new auto(std::async(std::launch::async, [] {
+			LogWindow::Log(LogWindow::logLevels::LOGLEVEL_INFO, "PACKAGEWINDOW", "Creating SDK...");
+			SDKGeneration::Generate(anyProgressDone, anyProgressTotal, FeatureFlags::SDK::EXPERIMENTAL_INTERNAL);
 			LogWindow::Log(LogWindow::logLevels::LOGLEVEL_INFO, "PACKAGEWINDOW", "Done!");
 			presentTopMostCallback = false;
 			}))).reset();


### PR DESCRIPTION
This PR sets out to introduce a workable output from the SDK generator that is suitable for internal usage. It tries to flesh out the function bodies as best it can to look up functions from the vtable and invoke them. Any functions for which we don't have all the required types defined (e.g. FString), it'll fall back to commenting as before.

It also introduces some other features like automatic includes of dependencies.

Tested by compiling the resulting SDK for Back4Blood without any compilation errors.

![image](https://github.com/Spuckwaffel/UEDumper/assets/164651398/5184009a-a8cc-4eda-93aa-da903b8d396c)

Example snippet of part of the generated SDK:
```
// Function /Script/Engine.PlayerController.ClientSetCameraFade
void ClientSetCameraFade(bool bEnableFading, FColor FadeColor, FVector2D FadeAlpha, float FadeTime, bool bFadeAudio) // [0x43c0c50] Net|NetReliableNative|Event|Public|HasDefaults|NetClient 
{
	typedef void (*FuncPtr)(bool, FColor, FVector2D, float, bool);
	auto vtablePtr = reinterpret_cast<uintptr_t*>(vtable);
	auto func = reinterpret_cast<FuncPtr>(vtablePtr[98]);
	func(bEnableFading, FadeColor, FadeAlpha, FadeTime, bFadeAudio);
}
// Function /Script/Engine.PlayerController.ClientSetBlockOnAsyncLoading
void ClientSetBlockOnAsyncLoading() // [0x43c0f50] Net|NetReliableNative|Event|Public|NetClient 
{
	typedef void (*FuncPtr)();
	auto vtablePtr = reinterpret_cast<uintptr_t*>(vtable);
	auto func = reinterpret_cast<FuncPtr>(vtablePtr[99]);
	func();
}
// Function /Script/Engine.PlayerController.ClientReturnToMainMenuWithTextReason
// void ClientReturnToMainMenuWithTextReason(FText ReturnReason);                                                           // [0x43c5750] Net|NetReliableNative|Event|Public|NetClient 
// Function /Script/Engine.PlayerController.ClientReturnToMainMenu
// void ClientReturnToMainMenu(FString ReturnReason);                                                                       // [0x43c5850] Net|NetReliableNative|Event|Public|NetClient 
// Function /Script/Engine.PlayerController.ClientRetryClientRestart
void ClientRetryClientRestart(APawn* NewPawn) // [0x43bdbd0] Net|NetReliableNative|Event|Public|NetClient 
{
	typedef void (*FuncPtr)(APawn*);
	auto vtablePtr = reinterpret_cast<uintptr_t*>(vtable);
	auto func = reinterpret_cast<FuncPtr>(vtablePtr[102]);
	func(NewPawn);
}
// Function /Script/Engine.PlayerController.ClientRestart
void ClientRestart(APawn* NewPawn) // [0x43c0f70] Net|NetReliableNative|Event|Public|NetClient 
{
	typedef void (*FuncPtr)(APawn*);
	auto vtablePtr = reinterpret_cast<uintptr_t*>(vtable);
	auto func = reinterpret_cast<FuncPtr>(vtablePtr[103]);
	func(NewPawn);
}
```

I contemplated using a macro for the function bodies, but since each ptr type is unique, I decided it wasn't worth the added complexity.