### PR TITLE
Fix saving and restoring of maxSize property

### DIFF
--- a/UEDumper/Engine/Core/EngineStructs.h
+++ b/UEDumper/Engine/Core/EngineStructs.h
@@ -339,7 +339,6 @@ namespace EngineStructs
 		int maxSize = 0; //the maximum size this struct is "allowed" to have, as size is not accurate due to padding and trailing
 		int minAlignment = 0; //minimal alignment defined by ue
 		int size = 0; //true size of the struct
-		int maxSize = 0; // max size of the struct
 		int inheretedSize = 0; //size of the inherited structs
 		int unknownCount = 0; //keep track of all missed vars, only used for the package viewer to edit unknowndata
 		std::vector<Member> definedMembers{}; //list of all members that are all valid and known

--- a/UEDumper/Engine/Core/EngineStructs.h
+++ b/UEDumper/Engine/Core/EngineStructs.h
@@ -339,6 +339,7 @@ namespace EngineStructs
 		int maxSize = 0; //the maximum size this struct is "allowed" to have, as size is not accurate due to padding and trailing
 		int minAlignment = 0; //minimal alignment defined by ue
 		int size = 0; //true size of the struct
+		int maxSize = 0; // max size of the struct
 		int inheretedSize = 0; //size of the inherited structs
 		int unknownCount = 0; //keep track of all missed vars, only used for the package viewer to edit unknowndata
 		std::vector<Member> definedMembers{}; //list of all members that are all valid and known
@@ -371,6 +372,7 @@ namespace EngineStructs
 			j["spn"] = superNames;
 			j["in"] = inherited;
 			j["sz"] = size;
+			j["msz"] = maxSize;
 			j["is"] = inheretedSize;
 			j["uc"] = unknownCount;
 			nlohmann::json jMembers;
@@ -394,6 +396,7 @@ namespace EngineStructs
 			s.superNames = json["spn"];
 			s.inherited = json["in"];
 			s.size = json["sz"];
+			s.maxSize = json["msz"];
 			s.inheretedSize = json["is"];
 			s.unknownCount = json["uc"];
 			for (const nlohmann::json& member : json["m"])


### PR DESCRIPTION
Tested by dumping a game fresh, saving, restarting dumper, loading it again. Confirmed the error messages checking for maxSize of zero no longer trigger.