### PR TITLE
Add FString to BasicTypes.h in SDK

### DIFF
--- a/UEDumper/Engine/Generation/BasicType.h
+++ b/UEDumper/Engine/Generation/BasicType.h
@@ -110,6 +110,47 @@ public:
 )";
     definedStructs.push_back(dStruct);
 
+    dStruct.name = "FString";
+    dStruct.definition =
+        R"(
+struct FString : public TArray<wchar_t>
+{
+    inline FString() {};
+
+    FString(const wchar_t* other)
+    {
+        Max = Count = *other ? static_cast<int32_t>(std::wcslen(other)) + 1 : 0;
+
+        if (Count)
+        {
+            Data = const_cast<wchar_t*>(other);
+        }
+    };
+
+    inline bool IsValid() const
+    {
+        return Data != nullptr;
+    }
+
+    inline const wchar_t* c_str() const
+    {
+        return Data;
+    }
+
+    std::string ToString() const
+    {
+        const auto length = std::wcslen(Data);
+
+        std::string str(length, '\0');
+
+        std::use_facet<std::ctype<wchar_t>>(std::locale()).narrow(Data, Data + length, '?', &str[0]);
+
+        return str;
+    }
+};
+)";
+    definedStructs.push_back(dStruct);
+
     dStruct.name = "FName";
     dStruct.definition =
         R"(

--- a/UEDumper/Engine/Generation/SDK.cpp
+++ b/UEDumper/Engine/Generation/SDK.cpp
@@ -36,6 +36,9 @@ void SDKGeneration::generateBasicType()
             noDefs.erase(it);
 
     BasicType << "#pragma once" << std::endl;
+    BasicType << "#include <cstdint>" << std::endl;
+    BasicType << "#include <locale>" << std::endl;
+    BasicType << "#include <Windows.h>" << std::endl;
 
     printCredits(BasicType);
     BasicType << "/// This file contains all definitions of structs that werent defined automatically.\n\n";


### PR DESCRIPTION
FString was previously undefined. This copies the definition from the Dumper and adds it to basic types.