### PR TITLE
fix param names when digits or reserved names are used

### DIFF
--- a/UEDumper/Engine/Core/Core.cpp
+++ b/UEDumper/Engine/Core/Core.cpp
@@ -18,8 +18,7 @@
 //flag some invalid characters in a name
 std::string generateValidVarName(const std::string& str)
 {
-	const static std::unordered_set<std::string> reservedNames{"float", "int", "bool", "double", "long", "char", "TRUE", "FALSE"};
-
+	//flag some invalid characters in a name
 	std::string result = "";
 	for (const char c : str)
 	{
@@ -29,13 +28,9 @@ std::string generateValidVarName(const std::string& str)
 			result += c;
 
 	}
-	if (std::isdigit(result[0])) result = "m" + result;
-
-	if (reservedNames.contains(result)) result += "0";
 
 	return result;
 };
-
 
 //we always compare this function to FName::ToString(FString& Out) in the source code
 std::string EngineCore::FNameToString(FName fname)

--- a/UEDumper/Engine/Generation/SDK.cpp
+++ b/UEDumper/Engine/Generation/SDK.cpp
@@ -105,6 +105,12 @@ void SDKGeneration::generatePackage(
                 result += c;
 
         }
+
+        const static std::unordered_set<std::string> reservedNames{ "float", "int", "bool", "double", "long", "char", "TRUE", "FALSE" };
+
+        if (std::isdigit(result[0])) result = "_" + result;
+        if (reservedNames.contains(result)) result += "0";
+
         //guaranteed 0 termination
         return result;
     };


### PR DESCRIPTION
Fortnite generates params that start with digits or reserved names like 'bool', 'float' when generating internal SDK. This fixes it.