### PR TITLE
Fix: Enums could have invalid chars in them in the MDK (e.g. Enum_Fog-Presets)

### DIFF
--- a/UEDumper/Engine/Generation/MDK.cpp
+++ b/UEDumper/Engine/Generation/MDK.cpp
@@ -230,7 +230,7 @@ void MDKGeneration::generatePackage(std::ofstream& stream, const EngineStructs::
 		char buf[100] = { 0 };
 		sprintf_s(buf, "Size: 0x%02d", enu.members.size());
 		stream << "/// " << buf << std::endl;
-		stream << "enum class " << enu.cppName << " : " << enu.type << std::endl;
+		stream << "enum class " << generateValidVarName(enu.cppName) << " : " << enu.type << std::endl;
 		stream << "{" << std::endl;
 
 		int j = 0;


### PR DESCRIPTION
Got a report of invalid enums being generated in the MDK. Tracked it down to it not being passed through generateValidVarName like other definitions are.