### PR TITLE
Fixed some important issues

### DIFF
--- a/UEDumper/Engine/Core/Core.cpp
+++ b/UEDumper/Engine/Core/Core.cpp
@@ -440,13 +440,13 @@ bool EngineCore::generateEnum(const UEnum* object, std::vector<EngineStructs::En
 	for (int i = 0; i < names.size(); i++)
 	{
 		auto& name = names[i];
-		if (name.Value() > maxNum && i != names.size() - 1) maxNum = name.Value();
+		if (name.GetValue() > maxNum && i != names.size() - 1) maxNum = name.GetValue();
 
-		auto fname = FNameToString(name.Key());
+		auto fname = FNameToString(name.GetKey());
 		std::ranges::replace(fname, ':', '_');
 
 		if (!fname.ends_with("_MAX"))
-			eEnum.members.push_back(std::pair(fname, name.Value()));
+			eEnum.members.push_back(std::pair(fname, name.GetValue()));
 	}
 	eEnum.type = setEnumSizeForValue(maxNum);
 	eEnum.size = getEnumSizeFromType(eEnum.type);

--- a/UEDumper/Engine/Userdefined/StructDefinitions.h
+++ b/UEDumper/Engine/Userdefined/StructDefinitions.h
@@ -341,7 +341,7 @@ inline void addStructs()
 	Tmap.maxSize = Tmap.size;
 	Tmap.noFixedSize = true;
 	Tmap.definedMembers = std::vector<EngineStructs::Member>{
-		{{true,		PropertyType::ObjectProperty,		"TArray"},		"Data",	0, 16},
+		{{true,		PropertyType::ArrayProperty,		"TArray"},		"Data",	0, 16},
 		{{false,		PropertyType::ArrayProperty,		TYPE_UCHAR},		"UnknownData01[0x40]",	16, 0x40},
 	};
 	//add it

--- a/UEDumper/Engine/structs.h
+++ b/UEDumper/Engine/structs.h
@@ -100,7 +100,7 @@ struct FUObjectItem
 };
 
 
-template <class T>
+template <typename T>
 struct TArray
 {
     friend struct FString;
@@ -202,12 +202,15 @@ struct FString : public TArray<wchar_t>
     }
 };
 
-template<typename Key, typename Value>
-class TMap
+template<typename ElementType>
+class TSetElement
 {
 public:
-    char UnknownData[0x50];
+    ElementType                                                Value;                                                   // 0x0000(0x0000)
+    int32_t                                                    HashNextId;                                              // 0x0000(0x0000)
+    int32_t                                                    HashIndex;                                               // 0x0000(0x0000)
 };
+
 
 class FScriptInterface
 {
@@ -393,22 +396,30 @@ public:
     TPair() {};
 
 public:
-    FORCEINLINE KeyType& Key()
+    FORCEINLINE KeyType& GetKey()
     {
         return First;
     }
-    FORCEINLINE const KeyType& Key() const
+    FORCEINLINE const KeyType& GetKey() const
     {
         return First;
     }
-    FORCEINLINE ValueType& Value()
+    FORCEINLINE ValueType& GetValue()
     {
         return Second;
     }
-    FORCEINLINE const ValueType& Value() const
+    FORCEINLINE const ValueType& GetValue() const
     {
         return Second;
     }
+};
+
+template<typename Key, typename Value>
+class TMap
+{
+public:
+    TArray<TSetElement<TPair<Key, Value>>>                     Data;
+    char UnknownData[0x40];
 };
 
 template <typename PtrType>

--- a/UEDumper/Frontend/Windows/LiveEditor.cpp
+++ b/UEDumper/Frontend/Windows/LiveEditor.cpp
@@ -549,16 +549,6 @@ void windows::LiveEditor::drawMemberArrayProperty(const EngineStructs::Member& m
 				ImGui::TreePop();
 				return;
 			}
-			//we get the first pointer so we can check what class the array indexes really are (tarray lies just like pointers)
-			const uint64_t firstIndexPtr = arrBlock->read<uint64_t>(0);
-			//look for the struct
-			if (!isValidStructName(firstIndexPtr, member.type.subTypes[0].name, st, true))
-			{
-				//this should never fail!
-				ImGui::TextColored(IGHelper::Colors::red, "Struct or Class doesnt exist in the SDK!");
-				ImGui::TreePop();
-				return;
-			}
 
 			//create a vector where we will iterate through
 			std::vector<uint64_t> objs(arr.Count);
@@ -579,6 +569,13 @@ void windows::LiveEditor::drawMemberArrayProperty(const EngineStructs::Member& m
 				//create a tree node for it
 				if (ImGui::TreeNode(std::string(std::to_string(i) + " " + member.type.subTypes[0].name + "##" + secret + std::to_string(objPtr)).c_str()))
 				{
+					if (!isValidStructName(objPtr, member.type.subTypes[0].name, st, true))
+					{
+						//this should never fail!
+						ImGui::TextColored(IGHelper::Colors::red, "Struct or Class doesnt exist in the SDK!");
+						ImGui::TreePop();
+						return;
+					}
 					ImGui::PopStyleColor();
 					ImGui::SameLineEx(0);
 					//add the *


### PR DESCRIPTION
- TArray is an ArrayProperty in StructDefinitions.h
- Renamed Key() and Value() method to GetKey and GetValue since methods with the same name as members can cause problems
- Moved class checking for ArrayProperty inside the for loop in LiveEditor.cpp since elements of a TArray aren't all necessarily of the same type, they are all just inheritors of the subtype template in OOP
- Added TMap type in structs.h